### PR TITLE
hotfix/CP-7313-ios-subscribe-function-does-not-report-an-error-message

### DIFF
--- a/ios/Plugin/CleverPushCapacitorPlugin.m
+++ b/ios/Plugin/CleverPushCapacitorPlugin.m
@@ -216,7 +216,7 @@ static NSString * _pendingLaunchOptions;
                 [call resolve:@{@"subscriptionId": subscriptionId}];
             }
         } failure:^(NSError *error) {
-            if (self.pluginCallDelegate != nil && call.callbackId != nil) {
+            if (self.pluginCallDelegate != nil || call.callbackId != nil) {
                 [call reject:error.localizedDescription ?: @"" :nil :nil :nil];
             }
         }];


### PR DESCRIPTION
Optimise the `subscribe` function for failure messages.