### PR TITLE
hotfix/CP-8099-capacitor-sdk-ios-clever-push-plugin-should-be-automatically-registered-if-it-is-not-registered-v1

### DIFF
--- a/android/src/main/java/com/cleverpush/plugins/capacitor/CleverPushCapacitorPlugin.java
+++ b/android/src/main/java/com/cleverpush/plugins/capacitor/CleverPushCapacitorPlugin.java
@@ -65,6 +65,18 @@ public class CleverPushCapacitorPlugin extends Plugin {
     @PluginMethod
     public void init(PluginCall call) {
 
+        try {
+            Bridge bridge = this.bridge;
+            if (bridge != null) {
+                PluginHandle pluginHandle = bridge.getPlugin("CleverPush");
+                if (pluginHandle == null) {
+                    bridge.registerPlugin(CleverPushCapacitorPlugin.class);
+                }
+            }
+        } catch (Exception e) {
+            System.out.println(e.getLocalizedMessage());
+        }
+
         NotificationReceivedCallbackListener receivedListener = new NotificationReceivedCallbackListener() {
             @Override
             public boolean notificationReceivedCallback(NotificationOpenedResult result) {


### PR DESCRIPTION
Cleverpush plugin should be automatically registered if it is not registered.